### PR TITLE
Fix output

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,12 +254,26 @@ func origMain(isOptionSpecified bool) {
 	resultDir := filepath.Dir(formattedOutDir) + "\\" + chartId
 
 	isAdminPerm := func(path string) bool {
+		created := false
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				return true
+			}
+			created = true
+		}
+
 		testFile := filepath.Join(path, ".test_access")
-		err := os.WriteFile(testFile, []byte("test"), 0644)
-		if err != nil {
+		if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
 			return true
 		}
-		os.Remove(testFile)
+
+		// cleanup test file
+		_ = os.Remove(testFile)
+
+		if created {
+			_ = os.Remove(path)
+		}
+
 		return false
 	}
 	if isAdminPerm(formattedOutDir) {


### PR DESCRIPTION
isAdminPerm implementation has been revised.

To prevent false positives caused by non-existent output directories, the implementation now creates directories if necessary, performs write tests, and attempts cleanup.

<img width="1110" height="616" alt="bug" src="https://github.com/user-attachments/assets/a432807a-0bed-40f8-ad93-c78ac5dbc5eb" />
